### PR TITLE
Nooping on unsupported scenarios

### DIFF
--- a/src/BenchmarkDb/DriverBase.cs
+++ b/src/BenchmarkDb/DriverBase.cs
@@ -9,6 +9,8 @@ namespace BenchmarkDb
 {
     public abstract class DriverBase
     {
+        public static Func<string, Task> NotSupportedVariation = _ => null;
+
         protected static void CheckResults(ICollection<Fortune> results)
         {
             if (results.Count != 12)
@@ -17,7 +19,7 @@ namespace BenchmarkDb
             }
         }
 
-        public Func<string, Task> TryGetVariation(string variationName)
+        public virtual Func<string, Task> TryGetVariation(string variationName)
         {
             switch (variationName)
             {
@@ -29,41 +31,29 @@ namespace BenchmarkDb
                     return DoWorkAsync;
                 case Variation.AsyncCaching:
                     return DoWorkAsyncCaching;
-            }
-
-            return default;
-        }
-
-        public virtual async Task DoWorkSync(string connectionString)
-        {
-            while (Program.IsRunning)
-            {
-                await Task.Delay(100);
+                default:
+                    return null;
             }
         }
 
-        public virtual async Task DoWorkSyncCaching(string connectionString)
+        public virtual Task DoWorkSync(string connectionString)
         {
-            while (Program.IsRunning)
-            {
-                await Task.Delay(100);
-            }
+            throw VariationNotSupported(Variation.Sync);
         }
 
-        public virtual async Task DoWorkAsync(string connectionString)
+        public virtual Task DoWorkSyncCaching(string connectionString)
         {
-            while (Program.IsRunning)
-            {
-                await Task.Delay(100);
-            }
+            throw VariationNotSupported(Variation.SyncCaching);
         }
 
-        public virtual async Task DoWorkAsyncCaching(string connectionString)
+        public virtual Task DoWorkAsync(string connectionString)
         {
-            while (Program.IsRunning)
-            {
-                await Task.Delay(100);
-            }
+            throw VariationNotSupported(Variation.Async);
+        }
+
+        public virtual Task DoWorkAsyncCaching(string connectionString)
+        {
+            throw VariationNotSupported(Variation.AsyncCaching);
         }
 
         private static Exception VariationNotSupported(string variationName)

--- a/src/BenchmarkDb/DriverBase.cs
+++ b/src/BenchmarkDb/DriverBase.cs
@@ -34,24 +34,36 @@ namespace BenchmarkDb
             return default;
         }
 
-        public virtual Task DoWorkSync(string connectionString)
+        public virtual async Task DoWorkSync(string connectionString)
         {
-            throw VariationNotSupported(Variation.Sync);
+            while (Program.IsRunning)
+            {
+                await Task.Delay(100);
+            }
         }
 
-        public virtual Task DoWorkSyncCaching(string connectionString)
+        public virtual async Task DoWorkSyncCaching(string connectionString)
         {
-            throw VariationNotSupported(Variation.SyncCaching);
+            while (Program.IsRunning)
+            {
+                await Task.Delay(100);
+            }
         }
 
-        public virtual Task DoWorkAsync(string connectionString)
+        public virtual async Task DoWorkAsync(string connectionString)
         {
-            throw VariationNotSupported(Variation.Async);
+            while (Program.IsRunning)
+            {
+                await Task.Delay(100);
+            }
         }
 
-        public virtual Task DoWorkAsyncCaching(string connectionString)
+        public virtual async Task DoWorkAsyncCaching(string connectionString)
         {
-            throw VariationNotSupported(Variation.AsyncCaching);
+            while (Program.IsRunning)
+            {
+                await Task.Delay(100);
+            }
         }
 
         private static Exception VariationNotSupported(string variationName)

--- a/src/BenchmarkDb/DriverBase.cs
+++ b/src/BenchmarkDb/DriverBase.cs
@@ -31,9 +31,9 @@ namespace BenchmarkDb
                     return DoWorkAsync;
                 case Variation.AsyncCaching:
                     return DoWorkAsyncCaching;
-                default:
-                    return null;
             }
+
+            return default;
         }
 
         public virtual Task DoWorkSync(string connectionString)

--- a/src/BenchmarkDb/PeregrineDriver.cs
+++ b/src/BenchmarkDb/PeregrineDriver.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Npgsql;
@@ -10,16 +11,19 @@ namespace BenchmarkDb
 {
     public sealed class PeregrineDriver : DriverBase
     {
+        public override Func<string, Task> TryGetVariation(string variationName)
+        {
+            switch (variationName)
+            {
+                case Variation.AsyncCaching:
+                    return DoWorkAsyncCaching;
+                default:
+                    return NotSupportedVariation;
+            }
+        }
+
         public override async Task DoWorkAsync(string connectionString)
         {
-            // Ingnoring this scenario until it's fixed
-            while (Program.IsRunning)
-            {
-                await Task.Delay(100);
-            }
-
-            return;
-
             var npgsqConnectionStringBuilder
                 = new NpgsqlConnectionStringBuilder(connectionString);
 

--- a/src/BenchmarkDb/PeregrineDriver.cs
+++ b/src/BenchmarkDb/PeregrineDriver.cs
@@ -12,6 +12,14 @@ namespace BenchmarkDb
     {
         public override async Task DoWorkAsync(string connectionString)
         {
+            // Ingnoring this scenario until it's fixed
+            while (Program.IsRunning)
+            {
+                await Task.Delay(100);
+            }
+
+            return;
+
             var npgsqConnectionStringBuilder
                 = new NpgsqlConnectionStringBuilder(connectionString);
 

--- a/src/BenchmarkDb/Program.cs
+++ b/src/BenchmarkDb/Program.cs
@@ -114,8 +114,6 @@ namespace BenchmarkDb
             var totalTransactions = 0;
             var results = new List<double>();
 
-            Interlocked.Exchange(ref _running, 1);
-
             IEnumerable<Task> CreateTasks()
             {
                 yield return Task.Run(
@@ -170,6 +168,13 @@ namespace BenchmarkDb
                 }
             }
 
+            if (variation == DriverBase.NotSupportedVariation)
+            {
+                return 0;
+            }
+
+            Interlocked.Exchange(ref _running, 1);
+
             await Task.WhenAll(CreateTasks());
 
             var totalTps = (int)(totalTransactions / (stopTime - startTime).TotalSeconds);
@@ -189,9 +194,9 @@ namespace BenchmarkDb
             var stdDev = CalculateStdDev(results);
 
             Console.SetCursorPosition(0, Console.CursorTop);
-            Console.WriteLine($"{threadCount:D2} Threads, tps: {totalTps:F2}, stddev(w/o best+worst): {stdDev:F2}");
+            Console.WriteLine($"{driverName} {variationName} {threadCount:D2} Threads, tps: {totalTps:F2}, stddev(w/o best+worst): {stdDev:F2}");
 
-            var desc = $"{driver}+{variationName}+{threadCount}";
+            var desc = $"{driverName}+{variationName}+{threadCount}";
 
             using (var sw = File.AppendText("results.md"))
             {


### PR DESCRIPTION
This way I can make a script that goes over all variations/drivers. It will just output 0 for the unsupported ones.