### PR TITLE
Add connection string checks for MySql

### DIFF
--- a/src/BenchmarkDb/BenchmarkDb.csproj
+++ b/src/BenchmarkDb/BenchmarkDb.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MySqlConnector" Version="0.28.2" />
+    <PackageReference Include="MySqlConnector" Version="0.37.0" />
     <PackageReference Include="Npgsql" Version="3.2.5" />
     <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />

--- a/src/BenchmarkDb/MySqlAdoDriver.cs
+++ b/src/BenchmarkDb/MySqlAdoDriver.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data.Common;
+using MySql.Data.MySqlClient;
+
+namespace BenchmarkDb
+{
+    public sealed class MySqlAdoDriver : AdoDriver
+    {
+        public MySqlAdoDriver() : base(MySqlClientFactory.Instance) {}
+
+        public override void Initialize(string connectionString, int threadCount)
+        {
+            var settings = new MySqlConnectionStringBuilder(connectionString);
+
+            var message = "";
+            if (settings.ConnectionIdlePingTime < 300)
+                message += "* ConnectionIdlePingTime=300 (or higher)\n";
+            if (settings.ConnectionReset)
+                message += "* ConnectionReset=false\n";
+            if (settings.DefaultCommandTimeout != 0)
+                message += "* DefaultCommandTimeout=0\n";
+            if (settings.SslMode != MySqlSslMode.None)
+                message += "* SslMode=None\n";
+            if (message.Length != 0)
+                throw new ArgumentException("ado-mysql requires the following connection string settings:\n" + message);
+
+            base.Initialize(connectionString, threadCount);
+        }
+    }
+}

--- a/src/BenchmarkDb/Program.cs
+++ b/src/BenchmarkDb/Program.cs
@@ -35,7 +35,7 @@ namespace BenchmarkDb
             = new Dictionary<string, DriverBase>
             {
                 { "ado-npgsql", new NpgsqlAdoDriver() },
-                { "ado-mysql", new AdoDriver(MySqlClientFactory.Instance) },
+                { "ado-mysql", new MySqlAdoDriver() },
                 { "ado-sqlclient", new AdoDriver(SqlClientFactory.Instance) },
                 { "ado-sqlite", new AdoDriver(SqliteFactory.Instance) },
                 { "peregrine", new PeregrineDriver() },


### PR DESCRIPTION
Checks that the following settings are enabled (for high performance) in the connection string:

* `SslMode=None`
* `ConnectionReset=false`
* `DefaultCommandTimeout=0`
* `ConnectionIdlePingTime=300`

See #35 for when Npgsql made similar changes.